### PR TITLE
[GT Serviços] PSV-XXX- Pagamentos - 4.1.0 : Adição de um novo endpoint para permitir a consulta de pagamentos através do consentimento

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -197,7 +197,7 @@ info:
       ## Quantidade máxima permitida para agendamentos recorrentes
       A quantidade máxima de pagamentos que podem transitar do iniciador para o detentor são de 60 pagamentos, independente do modelo de recorrência definido no consentimento, respeitando o prazo máximo de dois anos para agendamentos. 
       Caso a opção de recorrência enviada pelo iniciador não respeite a regra acima, o detentor deve retornar o erro 422 "PARAMETRO_INVALIDO" com o detalhe "Quantidade permitida de pagamentos excedida". 
-  version: 4.0.0
+  version: 4.1.0
   license:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0'
@@ -283,6 +283,50 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/200PaymentsConsentsConsentIdRead'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '529':
+          $ref: '#/components/responses/SiteIsOverloaded'
+        default:
+          description: Erro inesperado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+      security:
+        - OAuth2ClientCredentials:
+            - payments
+  '/consents/{consentId}/payments':
+    get:
+      tags:
+        - Pagamentos
+      summary: Consultar pagamentos gerados a partir de um consentimento.
+      operationId: paymentsGetConsentsConsentIdPayments
+      description: Método para consulta de pagamentos gerados a partir do consentimento indicado.
+      parameters:
+        - $ref: '#/components/parameters/startDate'
+        - $ref: '#/components/parameters/endDate'        
+        - $ref: '#/components/parameters/consentId'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+      responses:
+        '200':
+          $ref: '#/components/responses/200PaymentsConsentsConsentIdPaymentsRead'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1982,6 +2026,58 @@ components:
           $ref: '#/components/schemas/LinkSingle'
         meta:
           $ref: '#/components/schemas/Meta'
+    ResponsePaymentsGetConsentsConsentIdPayments:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          type: array
+          description: Objeto contendo dados do pagamento
+          items:
+            type: object
+            required:
+              - paymentId
+              - endToEndId
+              - consentId
+              - creationDateTime
+              - statusUpdateDateTime
+              - status
+              - localInstrument
+              - payment
+              - creditorAccount
+              - cnpjInitiator
+              - debtorAccount
+            properties:
+              paymentId:
+                type: string
+                minLength: 1
+                maxLength: 100
+                pattern: '^[a-zA-Z0-9][a-zA-Z0-9\-]{0,99}$'
+                example: TXpRMU9UQTROMWhZV2xSU1FUazJSMDl
+                description: |
+                  Código ou identificador único informado pela instituição detentora da conta para representar
+                  a iniciação de pagamento individual. O `paymentId` deve ser diferente do `endToEndId`.
+                  Este é o identificador que deverá ser utilizado na consulta ao status da iniciação de pagamento efetuada.
+              endToEndId:
+                $ref: '#/components/schemas/EndToEndId'
+              statusUpdateDateTime:
+                type: string
+                format: date-time
+                pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])T(?:[01]\d|2[0123]):(?:[012345]\d):(?:[012345]\d)Z$'
+                example: '2020-07-21T08:30:00Z'
+                description: |
+                  Data e hora da última atualização da iniciação de pagamento.
+                  Uma string com data e hora conforme especificação RFC-3339,
+                  sempre com a utilização de timezone UTC(UTC time format).
+              status:
+                $ref: '#/components/schemas/EnumPaymentStatusType'
+        links:
+          $ref: '#/components/schemas/LinkSingle'
+        meta:
+          $ref: '#/components/schemas/Meta'
     ResponseCreatePaymentConsent:
       type: object
       required:
@@ -2811,6 +2907,28 @@ components:
         type: string
         pattern: '^[a-zA-Z0-9][a-zA-Z0-9\-]{0,99}$'
         maxLength: 100
+    startDate:
+      name: startDate
+      in: query
+      description: Data inicial de corte da ocorrência do pagamento ligada ao consentimento.
+      required: false
+      schema:
+        type: string
+        example: '2025-04-16'
+        pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$'
+        minLength: 10
+        maxLength: 10
+    endDate:
+      name: endDate
+      in: query
+      description: Data final de corte para recuperação do pagamento ligada ao consentimento.
+      required: false
+      schema:
+        type: string
+        example: '2025-04-17'
+        pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$'
+        minLength: 10
+        maxLength: 10
     Authorization:
       name: Authorization
       in: header
@@ -3124,6 +3242,18 @@ components:
         application/jwt:
           schema:
             $ref: '#/components/schemas/ResponsePaymentConsent'
+    200PaymentsConsentsConsentIdPaymentsRead:
+      description: Dados do consentimento de pagamento obtidos com sucesso.
+      headers:
+        x-fapi-interaction-id:
+          description: |
+            Um UUID [RFC4122](https://tools.ietf.org/html/rfc4122) usado como um ID de correlação entre request e response. Campo de geração e envio obrigatório pela iniciadora (client) e o seu valor deve ser “espelhado” pela detentora (server) no cabeçalho de resposta. Caso não seja enviado pela iniciadora, a detentora deve gerar um x-fapi-interaction-id e retorná-lo na resposta com o HTTP status code 400. Caso recebido um valor inválido, a detentora deve gerar um x-fapi-interaction-id e retorná-lo na resposta com o HTTP status code 400 ou 422 (com o código PARAMETRO_INVALIDO). A iniciadora deve acatar o valor gerado pelo detentor e recebido na resposta.
+          schema:
+            $ref: '#/components/schemas/XFapiInteractionId'
+      content:
+        application/jwt:
+          schema:
+            $ref: '#/components/schemas/ResponsePaymentsGetConsentsConsentIdPayments'
     201PaymentsInitiationPixPaymentCreated:
       description: Iniciação de pagamento Pix criada com sucesso.
       headers:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -514,6 +514,49 @@ paths:
         - OAuth2ClientCredentials:
             - payments
   '/pix/payments/consents/{consentId}':
+    get:
+      tags:
+        - Pagamentos
+      summary: Consultar pagamentos gerados a partir de um consentimento.
+      operationId: paymentsGetConsentsConsentIdPayments2
+      description: Método para consulta de pagamentos gerados a partir do consentimento indicado.
+      parameters:
+        - $ref: '#/components/parameters/startDate'
+        - $ref: '#/components/parameters/endDate'        
+        - $ref: '#/components/parameters/consentId'
+        - $ref: '#/components/parameters/Authorization'
+        - $ref: '#/components/parameters/xFapiAuthDate'
+        - $ref: '#/components/parameters/xFapiCustomerIpAddress'
+        - $ref: '#/components/parameters/xFapiInteractionId'
+        - $ref: '#/components/parameters/xCustomerUserAgent'
+      responses:
+        '200':
+          $ref: '#/components/responses/200PaymentsConsentsConsentIdPaymentsRead'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '405':
+          $ref: '#/components/responses/MethodNotAllowed'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+        '529':
+          $ref: '#/components/responses/SiteIsOverloaded'
+        default:
+          description: Erro inesperado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseError'
+      security:
+        - OAuth2ClientCredentials:
+            - payments
     patch:
       tags:
         - Pagamentos


### PR DESCRIPTION
### Contexto

Foi apresentando por uma cadeira uma questão relativa a incerteza da criação de recursos quando um erro HTTP 5XX ocorre durante sua operação. Para permitir uma maior segurança para os envolvidos, essa proposta visa permitir a consulta de recursos, criados ou não, quando um erro desse tipo ocorrer.

### Descrição

Adicionar um novo endpoint à API:
GET /consents/{consentId}/payments
