### PR TITLE
[GT de Serviços] PSV-226 - Payments - v4.1.0-rc.1: Proposta para adição da resposta de erro 504 seguindo a IN456

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -255,6 +255,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityConsents'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -297,6 +299,8 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -341,6 +345,8 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -394,6 +400,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityPixPayment'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -443,6 +451,8 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -503,6 +513,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityPixPayments'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -561,6 +573,8 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityPixPayments'
         '500':
           $ref: '#/components/responses/InternalServerError'
+        '504':
+          $ref: '#/components/responses/GatewayTimeout'
         '529':
           $ref: '#/components/responses/SiteIsOverloaded'
         default:
@@ -3087,7 +3101,19 @@ components:
       headers:
         x-fapi-interaction-id:
           description: |
-            Um UUID [RFC4122](https://tools.ietf.org/html/rfc4122) usado como um ID de correlação entre request e response. Campo de geração e envio obrigatório pela iniciadora (client) e o seu valor deve ser “espelhado” pela detentora (server) no cabeçalho de resposta. Caso não seja enviado pela iniciadora, a detentora deve gerar um x-fapi-interaction-id e retorná-lo na resposta com o HTTP status code 400. Caso recebido um valor inválido, a detentora deve gerar um x-fapi-interaction-id e retorná-lo na resposta com o HTTP status code 400 ou 422 (com o código PARAMETRO_INVALIDO). A iniciadora deve acatar o valor gerado pelo detentor e recebido na resposta.
+            Um UUID RFC4122 usado como um ID de correlação entre requeste response. Campo de geração e envio obrigatório pela iniciadora (client). Seu valor deve obrigatoriamente ser replicado pela detentora (server) no cabeçalho de resposta, exceto em casos de falhas estruturais que impeçam a replicação. Caso não seja possível ser replicado, não deve ser enviado.
+          schema:
+            $ref: '#/components/schemas/XFapiInteractionId'
+    GatewayTimeout:
+      description: A requisição não foi atendida dentro do tempo limite estabelecido
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: '#/components/schemas/ResponseError'
+      headers:
+        x-fapi-interaction-id:
+          description: |
+            Um UUID RFC4122 usado como um ID de correlação entre requeste response. Campo de geração e envio obrigatório pela iniciadora (client). Seu valor deve obrigatoriamente ser replicado pela detentora (server) no cabeçalho de resposta, exceto em casos de falhas estruturais que impeçam a replicação. Caso não seja possível ser replicado, não deve ser enviado.
           schema:
             $ref: '#/components/schemas/XFapiInteractionId'
     MethodNotAllowed:
@@ -3132,6 +3158,12 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/ResponseError'
+      headers:
+        x-fapi-interaction-id:
+          description: |
+            Um UUID RFC4122 usado como um ID de correlação entre requeste response. Campo de geração e envio obrigatório pela iniciadora (client). Seu valor deve obrigatoriamente ser replicado pela detentora (server) no cabeçalho de resposta, exceto em casos de falhas estruturais que impeçam a replicação. Caso não seja possível ser replicado, não deve ser enviado.
+          schema:
+            $ref: '#/components/schemas/XFapiInteractionId'
     UnprocessableEntityPixPayment:
       description: 'Seguir as orientações presentes na descrição da API, itens 2.2 e 2.3 e seus subitens.'
       content:


### PR DESCRIPTION
### Contexto

A partir da IN456, o GT e a DTO 
identificaram a necessidade 
depadronizar o response dos 
endpointsda API de 
Pagamentos, adicionando o 
status code504 (Gateway 
Timeout) para situação em que 
tempo de resposta do 
provedor para o consumidor 
exceda o tempo de quinze 
segundos na requisição
▪Essa padronização visa 
equalizar o ecossistema em 
relação aos tempos de 
chamadas e traz maior clareza 
para avaliação da PCM em 
relação as chamadas que são 
feitas pelos participantes

### Descrição

Adicionar o status code http 504 nos responses de todos os endpoints da API de Pagamentos.

