### PR TITLE
[GT de Serviços] PSV-295 - Payments - v4.1.0-rc.1: Proposta para adicionar novo motivo de rejeição assíncrono para pagamentos na API Pagamento

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -176,14 +176,15 @@ info:
       | Conclusão da autenticação        | FALHA_INFRAESTRUTURA         |          3          |
       |                                  | NAO_INFORMADO                |          4          |
       |----------------------------------|------------------------------|---------------------|
-      |                                  | CONTA_NAO_PERMITE_PAGAMENTO  |          1          |
-      |                                  | CONTAS_ORIGEM_DESTINO_IGUAIS |          2          |
-      |                                  | VALOR_INVALIDO               |          3          |
-      | Autorização do cliente           | QRCODE_INVALIDO              |          4          |
-      |                                  | VALOR_ACIMA_LIMITE           |          5          |
-      |                                  | SALDO_INSUFICIENTE           |          6          |
-      |                                  | FALHA_INFRAESTRUTURA         |          7          |
-      |                                  | NAO_INFORMADO                |          8          |
+      |                                  | AUTENTICACAO_DIVERGENTE      |          1          |
+      |                                  | CONTA_NAO_PERMITE_PAGAMENTO  |          2          |
+      |                                  | CONTAS_ORIGEM_DESTINO_IGUAIS |          3          |
+      |                                  | VALOR_INVALIDO               |          4          |
+      | Autorização do cliente           | QRCODE_INVALIDO              |          5          |
+      |                                  | VALOR_ACIMA_LIMITE           |          6          |
+      |                                  | SALDO_INSUFICIENTE           |          7          |
+      |                                  | FALHA_INFRAESTRUTURA         |          8          |
+      |                                  | NAO_INFORMADO                |          9          |
       |----------------------------------|------------------------------|---------------------|
       |                                  | FALHA_INFRAESTRUTURA         |          1          |
       | Authorisation code emitido       | NAO_INFORMADO                |          2          |
@@ -1365,6 +1366,7 @@ components:
     EnumConsentRejectionReasonType:
       type: string
       enum:
+        - AUTENTICACAO_DIVERGENTE
         - VALOR_INVALIDO
         - NAO_INFORMADO
         - FALHA_INFRAESTRUTURA
@@ -1379,6 +1381,7 @@ components:
       example: SALDO_INSUFICIENTE
       description: |
         Define o código da razão pela qual o consentimento foi rejeitado
+        - AUTENTICACAO_DIVERGENTE
         - VALOR_INVALIDO
         - NAO_INFORMADO
         - FALHA_INFRAESTRUTURA
@@ -1560,6 +1563,7 @@ components:
           maxLength: 2048
           description: |
             Contém informações adicionais ao consentimento rejeitado.
+            - AUTENTICACAO_DIVERGENTE : Usuário autenticado no detentor diverge do usuário autenticado no iniciador​
             - VALOR_INVALIDO: O valor enviado não é válido para o QR Code informado;
             - NAO_INFORMADO: Não informada pela detentora de conta;
             - FALHA_INFRAESTRUTURA: [Descrição de qual falha na infraestrutura inviabilizou o processamento].


### PR DESCRIPTION
### Contexto

A partir da análise do ticket 
#52195, GT e DTO 
identificaram que não há um 
motivo de rejeição que 
permita ao detentor rejeitar 
um consentimento quando a 
titularidade do usuário que 
realizou o loginna instituição 
detentora é diferente daquele 
que criou o consentimento e 
encontra-se logado no 
ambiente da Iniciadora

### Descrição

Adicionar ao headerda API pagamentos, no tópico 5, um novo item, 5.1.12, com o seguinte conteúdo:​Serviços
–Autenticação divergente: O usuário autenticado no ambiente da detentora não é o mesmo usuário autenticado 
no ambiente da iniciadora e que criou o consentimento. (AUTENTICACAO _DIVERGENTE)​

Adicionar novo motivo de rejeição do consentimento na resposta do GET /consents/{consentId}