### PR TITLE
[GT de Serviços] PSV-306 - Payments - v4.1.0-rc.1: GT Serviços – Proposta para corrigir divergências entre as orientações do header e os motivos de rejeição da API Pagamentos

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1454,9 +1454,9 @@ components:
 
         - CHAVE_PIX_DIVERGENTE_AGENDAMENTO_LIQUIDACAO: Divergências entre dados das chaves Pix no agendamento e na liquidação
 
-        - FALHA_AGENDAMENTO_PAGAMENTOS - Falha ao agendar pagamentos.
+        - FALHA_AGENDAMENTO_PAGAMENTOS - Falha ao agendar pagamentos.  
 
-        Os rejectionReasonsFALHA_INFRAESTRUTURA e CONTAS_ORIGEM_DESTINO_IGUAISnão serão excluídos, apenas deixaram de ser utilizados, permitindo assim, retrocompatibilidade e integridade com as versões anteriores da API.
+        Os rejectionReasons FALHA_INFRAESTRUTURA e CONTAS_ORIGEM_DESTINO_IGUAIS não serão excluídos, apenas deixaram de ser utilizados, permitindo assim, retrocompatibilidade e integridade com as versões anteriores da API.  
     EnumRejectionReasonType:
       type: string
       enum:
@@ -1513,9 +1513,9 @@ components:
 
         - CHAVE_PIX_DIVERGENTE_AGENDAMENTO_LIQUIDACAO: Divergências entre dados das chaves Pix no agendamento e na liquidação
 
-        - CONTAS_ORIGEM_DESTINO_IGUAIS - Indica uma tentativa de pagamento onde a conta origem e a conta de destino são iguais.
+        - CONTAS_ORIGEM_DESTINO_IGUAIS - Indica uma tentativa de pagamento onde a conta origem e a conta de destino são iguais.  
 
-        Os rejectionReasons FALHA_INFRAESTRUTURA e CONTAS_ORIGEM_DESTINO_IGUAI não serão excluídos, apenas deixaram de ser utilizados, permitindo assim, retrocompatibilidade e integridade com as versões anteriores da API.
+        Os rejectionReasons FALHA_INFRAESTRUTURA e CONTAS_ORIGEM_DESTINO_IGUAIS não serão excluídos, apenas deixaram de ser utilizados, permitindo assim, retrocompatibilidade e integridade com as versões anteriores da API.   
     EnumPaymentCancellationReasonType:
       type: string
       enum:


### PR DESCRIPTION
### Contexto

Durante análises internas da 
DTO, foram identificadas 
divergências entre os valores 
possíveis de motivos de 
rejeição e a descrição desses 
motivos, presentes no header
▪Também foi identificada a 
necessidade de remoção do 
motivo 
“CONTAS_ORIGEM_DESTINO_
IGUAIS” das possibilidades de 
motivo de rejeição para o 
pagamento, visto que tal 
motivo foi movido para os 
motivos de rejeição do 
consentimento
–Sendo assim, GT e DTO 
entendem necessário 
corrigir tanto o header
da API quanto o campo 
responsável pelos 
motivos de rejeição de 
pagamentos

### Descrição

No headerda API Pagamentos, no item “Validações”, em seu tópico 4, adicionar as novas entradas conforme Serviços
abaixo:
–4.1.11 -Erro de infraestrutura na consulta ao SPI: Ocorreu uma falha de infraestrutura durante a consulta ao 
DICT(FALHA_INFRAESTRUTURA_DICT)
–4.1.12 -Erro de infraestrutura na consulta ao ICP: Ocorreu uma falha de infraestrutura durante a consulta ao ICP 
(FALHA_INFRAESTRUTURA_ICP)
–4.1.13 -Erro de infraestrutura na comunicação com o PSP do recebedor: Ocorreu uma falha de infraestrutura 
durante a comunicação com o PSP do recebedor (FALHA_INFRAESTRUTURA_PSP_RECEBEDOR)
–4.1.14 -Erro de infraestrutura interno na detentora: Ocorreu uma falha de infraestrutura interna na detentora 
durante o processamento do pagamento (FALHA_INFRAESTRUTURA_DETENTORA)
–4.1.15 -Erro de infraestrutura na consulta ao SPI: Ocorreu uma falha de infraestrutura durante a consulta ao SPI 
(FALHA_INFRAESTRUTURA_SPI)
▪No responsede sucesso dos endpointsPOST /pix/payments, GET /pix/payments/{paymentId} e PATCH 
/pix/payments/{paymentId}:
–Alterar o seguinte trecho da descrição do ENUM “/data/rejectionReason/code”:
▫De: O rejectionReasonFALHA_INFRAESTRUTURA não será excluído, apenas deixará de ser utilizado, 
permitindo assim, retrocompatibilidade e integridade entre os participantes.
▫Para: Os rejectionReasonsFALHA_INFRAESTRUTURA e CONTAS_ORIGEM_DESTINO_IGUAISnão serão 
excluídos, apenas deixaram de ser utilizados, permitindo assim, retrocompatibilidade e integridade com as 
versões anteriores da API