### PR TITLE
[GT de Serviços] PSV-300 - Payments - v4.1.0-rc.1: GT Serviços – Proposta para ajustar o caminho do campo additionalInformation em consentimentos de pagamentos agendados na API Pagamentos

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -876,6 +876,18 @@ components:
         - $ref: '#/components/schemas/ScheduleWeekly'
         - $ref: '#/components/schemas/ScheduleMonthly'
         - $ref: '#/components/schemas/ScheduleCustom'
+      type: object
+      required:
+        - additionalInformation
+      properties:
+        additionalInformation:
+          type: string
+          description: |
+            Texto livre para Iniciador preencher de forma compreensível pelo usuário aprovador/pagador. 
+            O texto pode ser utilizado pelo detentor para exibição do resumo da transação durante aprovação do usuário aprovador/pagador.
+          pattern: '[\w\W\s]*'
+          maxLength: 255
+          example: Todas quintas e domingos por 6 meses
     CreatePixPayment:
       type: object
       required:
@@ -2874,7 +2886,6 @@ components:
             Caso datas repetidas sejam enviadas, o detentor deve rejeitar a criação do consentimento, informando o erro PARAMETRO_INVALIDO.
           required:
             - dates
-            - additionalInformation
           properties:
             dates:
               description: Define os dias em que estão planejadas as ocorrências das liquidações.
@@ -2888,14 +2899,6 @@ components:
                 pattern: '^(\d{4})-(1[0-2]|0?[1-9])-(3[01]|[12][0-9]|0?[1-9])$'
                 maxLength: 10
                 example: '2023-08-23'
-            additionalInformation:
-              type: string
-              description: |
-                Texto livre para Iniciador preencher de forma compreensível pelo usuário aprovador/pagador. 
-                O texto pode ser utilizado pelo detentor para exibição do resumo da transação durante aprovação do usuário aprovador/pagador.
-              pattern: '[\w\W\s]*'
-              maxLength: 255
-              example: Todas quintas e domingos por 6 meses
     XFapiInteractionId:
       type: string
       pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'


### PR DESCRIPTION
### Contexto
A partir da análise do ticket #37791, e com o intuito de reduzir a repetição de campos na API, GT e DTO entendem que, como não é possível realizar vários tipos de agendamento diferentes com um único consentimento, a existência de um único campo de informações adicionais (additionalInformation) é suficiente para descrever a periodicidade dos agendamentos, conforme previsto no Guia de UX

### Definição
Remover o campo "/data/payment/schedule/custom/additionalInformation".
▪ Adicionar o campo "/data/payment/schedule/additionalInformation", com a seguinte parametrização:
–Descrição: Texto livre para o Iniciador descrever de forma compreensível pelo usuário aprovador/pagador as características do agendamento solicitado. O texto pode ser utilizado pelo detentor para exibição do resumo da transação durante aprovação do usuário aprovador/pagador.
- Tamanho Máximo: 255
- Mandatoriedade: Obrigatório
- Pattern: [\w\W\s]*
- Tipo: String

▪ As alterações devem ocorrer nos seguintes locais:

- Requeste response201 do POST /consents
- Response200 do GET /consents/{consentId}
- Response200 do PATCH /consents/{consentId}